### PR TITLE
Separate Nefarian and Onyxia cooldowns

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -36,6 +36,14 @@ local options = {
             get = function() return FADEWTConfig.OnyxiaHidden end,
             set = function(_, value) FADEWTConfig.OnyxiaHidden = value; ReloadUI() end,
         },
+        Nefarian = {
+            order = 0,
+            type = "toggle",
+            name = "Hide Nefarian timers",
+            desc = "If checked Nefarian timers are hidden",
+            get = function() return FADEWTConfig.NefarianHidden end,
+            set = function(_, value) FADEWTConfig.NefarianHidden = value; ReloadUI() end,
+        },
         BroadcastYELL = {
             order = 0,
             type = "toggle",

--- a/FADEWorldTimers.lua
+++ b/FADEWorldTimers.lua
@@ -30,6 +30,7 @@ function FADEWT:Init()
     -- Register event on UNIT_AURA so we can check if player got Songflower
     Frame:RegisterEvent("UNIT_AURA")
     Frame:RegisterEvent("CHAT_MSG_LOOT")
+    Frame:RegisterEvent("CHAT_MSG_MONSTER_YELL")
     Frame:SetScript("OnEvent", FADEWT.HandleEvent)
     Comm:RegisterComm(FADEWT.COMMKEY, FADEWT.HandleMessage)
     --Comm:RegisterComm("FADEWorldTimers", FADEWT.RecvTimers)
@@ -51,6 +52,21 @@ function FADEWT:HandleEvent(event, ...)
 
     if event == "CHAT_MSG_LOOT" then
         FADEWT:OnChatMsgLoot(self, ...)
+    end
+
+    if event == "CHAT_MSG_MONSTER_YELL" then
+        FADEWT:OnChatMsgMonsterYell(self, ...)
+    end
+end
+
+function FADEWT:OnChatMsgMonsterYell(self, ...)
+    local msg, npc = ...
+    --print("msg " .. msg)
+    --print("npc " .. npc)
+    for _, Timer in ipairs(FADEWT.WorldTimers) do
+        if Timer.OnMsgMonsterYell ~= nil then
+            Timer:OnMsgMonsterYell(npc)
+        end
     end
 end
 

--- a/FADEWorldTimers.toc
+++ b/FADEWorldTimers.toc
@@ -3,7 +3,7 @@
 ## Author: Netzone
 ## Version: 1.0
 ## DefaultState: Enabled
-## SavedVariables: SongflowerTimers, WhipperRootTimers, OnyxiaTimers, WCBTimers, FADEWTConfig
+## SavedVariables: SongflowerTimers, WhipperRootTimers, OnyxiaTimers, NefarianTimers, WCBTimers, FADEWTConfig
 Libs\main.xml
 
 FADEWorldTimers.lua
@@ -11,5 +11,6 @@ Timers\Songflower.lua
 Timers\WarchiefsBlessing.lua
 Timers\Onyxia.lua
 Timers\WhipperRoot.lua
+Timers\Nefarian.lua
 
 Config.lua

--- a/FADEWorldTimers.toc
+++ b/FADEWorldTimers.toc
@@ -6,6 +6,8 @@
 ## SavedVariables: SongflowerTimers, WhipperRootTimers, OnyxiaTimers, NefarianTimers, WCBTimers, FADEWTConfig
 Libs\main.xml
 
+Locale\Locales.xml
+
 FADEWorldTimers.lua
 Timers\Songflower.lua
 Timers\WarchiefsBlessing.lua

--- a/Libs/AceLocale-3.0/AceLocale-3.0.lua
+++ b/Libs/AceLocale-3.0/AceLocale-3.0.lua
@@ -1,0 +1,137 @@
+--- **AceLocale-3.0** manages localization in addons, allowing for multiple locale to be registered with fallback to the base locale for untranslated strings.
+-- @class file
+-- @name AceLocale-3.0
+-- @release $Id: AceLocale-3.0.lua 1035 2011-07-09 03:20:13Z kaelten $
+local MAJOR,MINOR = "AceLocale-3.0", 6
+
+local AceLocale, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceLocale then return end -- no upgrade needed
+
+-- Lua APIs
+local assert, tostring, error = assert, tostring, error
+local getmetatable, setmetatable, rawset, rawget = getmetatable, setmetatable, rawset, rawget
+
+-- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
+-- List them here for Mikk's FindGlobals script
+-- GLOBALS: GAME_LOCALE, geterrorhandler
+
+local gameLocale = GetLocale()
+if gameLocale == "enGB" then
+	gameLocale = "enUS"
+end
+
+AceLocale.apps = AceLocale.apps or {}          -- array of ["AppName"]=localetableref
+AceLocale.appnames = AceLocale.appnames or {}  -- array of [localetableref]="AppName"
+
+-- This metatable is used on all tables returned from GetLocale
+local readmeta = {
+	__index = function(self, key) -- requesting totally unknown entries: fire off a nonbreaking error and return key
+		rawset(self, key, key)      -- only need to see the warning once, really
+		geterrorhandler()(MAJOR..": "..tostring(AceLocale.appnames[self])..": Missing entry for '"..tostring(key).."'")
+		return key
+	end
+}
+
+-- This metatable is used on all tables returned from GetLocale if the silent flag is true, it does not issue a warning on unknown keys
+local readmetasilent = {
+	__index = function(self, key) -- requesting totally unknown entries: return key
+		rawset(self, key, key)      -- only need to invoke this function once
+		return key
+	end
+}
+
+-- Remember the locale table being registered right now (it gets set by :NewLocale())
+-- NOTE: Do never try to register 2 locale tables at once and mix their definition.
+local registering
+
+-- local assert false function
+local assertfalse = function() assert(false) end
+
+-- This metatable proxy is used when registering nondefault locales
+local writeproxy = setmetatable({}, {
+	__newindex = function(self, key, value)
+		rawset(registering, key, value == true and key or value) -- assigning values: replace 'true' with key string
+	end,
+	__index = assertfalse
+})
+
+-- This metatable proxy is used when registering the default locale.
+-- It refuses to overwrite existing values
+-- Reason 1: Allows loading locales in any order
+-- Reason 2: If 2 modules have the same string, but only the first one to be
+--           loaded has a translation for the current locale, the translation
+--           doesn't get overwritten.
+--
+local writedefaultproxy = setmetatable({}, {
+	__newindex = function(self, key, value)
+		if not rawget(registering, key) then
+			rawset(registering, key, value == true and key or value)
+		end
+	end,
+	__index = assertfalse
+})
+
+--- Register a new locale (or extend an existing one) for the specified application.
+-- :NewLocale will return a table you can fill your locale into, or nil if the locale isn't needed for the players
+-- game locale.
+-- @paramsig application, locale[, isDefault[, silent]]
+-- @param application Unique name of addon / module
+-- @param locale Name of the locale to register, e.g. "enUS", "deDE", etc.
+-- @param isDefault If this is the default locale being registered (your addon is written in this language, generally enUS)
+-- @param silent If true, the locale will not issue warnings for missing keys. Must be set on the first locale registered. If set to "raw", nils will be returned for unknown keys (no metatable used).
+-- @usage
+-- -- enUS.lua
+-- local L = LibStub("AceLocale-3.0"):NewLocale("TestLocale", "enUS", true)
+-- L["string1"] = true
+--
+-- -- deDE.lua
+-- local L = LibStub("AceLocale-3.0"):NewLocale("TestLocale", "deDE")
+-- if not L then return end
+-- L["string1"] = "Zeichenkette1"
+-- @return Locale Table to add localizations to, or nil if the current locale is not required.
+function AceLocale:NewLocale(application, locale, isDefault, silent)
+
+	-- GAME_LOCALE allows translators to test translations of addons without having that wow client installed
+	local gameLocale = GAME_LOCALE or gameLocale
+
+	local app = AceLocale.apps[application]
+
+	if silent and app and getmetatable(app) ~= readmetasilent then
+		geterrorhandler()("Usage: NewLocale(application, locale[, isDefault[, silent]]): 'silent' must be specified for the first locale registered")
+	end
+
+	if not app then
+		if silent=="raw" then
+			app = {}
+		else
+			app = setmetatable({}, silent and readmetasilent or readmeta)
+		end
+		AceLocale.apps[application] = app
+		AceLocale.appnames[app] = application
+	end
+
+	if locale ~= gameLocale and not isDefault then
+		return -- nop, we don't need these translations
+	end
+
+	registering = app -- remember globally for writeproxy and writedefaultproxy
+
+	if isDefault then
+		return writedefaultproxy
+	end
+
+	return writeproxy
+end
+
+--- Returns localizations for the current locale (or default locale if translations are missing).
+-- Errors if nothing is registered (spank developer, not just a missing translation)
+-- @param application Unique name of addon / module
+-- @param silent If true, the locale is optional, silently return nil if it's not found (defaults to false, optional)
+-- @return The locale table for the current language.
+function AceLocale:GetLocale(application, silent)
+	if not silent and not AceLocale.apps[application] then
+		error("Usage: GetLocale(application[, silent]): 'application' - No locales registered for '"..tostring(application).."'", 2)
+	end
+	return AceLocale.apps[application]
+end

--- a/Libs/AceLocale-3.0/AceLocale-3.0.xml
+++ b/Libs/AceLocale-3.0/AceLocale-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceLocale-3.0.lua"/>
+</Ui>

--- a/Libs/main.xml
+++ b/Libs/main.xml
@@ -1,6 +1,7 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
 	<Script file="LibStub\LibStub.lua"/>
 	<Include file="AceGUI-3.0\AceGUI-3.0.xml"/>
+	<Include file="AceLocale-3.0\AceLocale-3.0.xml"/>
 	<Include file="AceTimer-3.0\AceTimer-3.0.xml"/>
 	<Include file="AceConfig-3.0\AceConfig-3.0.xml"/>
 	<Include file="AceSerializer-3.0\AceSerializer-3.0.xml"/>

--- a/Locale/Locales.xml
+++ b/Locale/Locales.xml
@@ -1,0 +1,7 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+    <Script file="enUS.lua"/>
+    <Script file="deDE.lua"/>
+</Ui>

--- a/Locale/deDE.lua
+++ b/Locale/deDE.lua
@@ -1,0 +1,7 @@
+-- deDE.lua
+local L = LibStub("AceLocale-3.0"):NewLocale("FADEWT", "deDE")
+
+L["Overlord Runthak"] = "Oberanführer Runthak"
+L["Major Mattingly"] = true
+L["High Overlord Saurfang"] = "Hochfürst Saurfang"
+L["Field Marshal Afrasiabi"] = "Feldmarschall Afrasiabi"

--- a/Locale/deDE.lua
+++ b/Locale/deDE.lua
@@ -1,5 +1,6 @@
 -- deDE.lua
 local L = LibStub("AceLocale-3.0"):NewLocale("FADEWT", "deDE")
+if not L then return end
 
 L["Overlord Runthak"] = "Oberanführer Runthak"
 L["Major Mattingly"] = true

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -1,0 +1,7 @@
+-- enUS.lua
+local L = LibStub("AceLocale-3.0"):NewLocale("FADEWT", "enUS", true)
+
+L["Overlord Runthak"] = true
+L["Major Mattingly"] = true
+L["High Overlord Saurfang"] = true
+L["Field Marshal Afrasiabi"] = true

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -1,5 +1,6 @@
 -- enUS.lua
 local L = LibStub("AceLocale-3.0"):NewLocale("FADEWT", "enUS", true)
+if not L then return end
 
 L["Overlord Runthak"] = true
 L["Major Mattingly"] = true

--- a/Timers/Nefarian.lua
+++ b/Timers/Nefarian.lua
@@ -4,6 +4,9 @@ local HBD = LibStub("HereBeDragons-2.0")
 local Comm = LibStub("AceComm-3.0")
 local Serializer = LibStub("AceSerializer-3.0")
 
+local L = LibStub("AceLocale-3.0"):GetLocale("FADEWT")
+
+
 FADEWT.Nefarian = {}
 FADEWT.Nefarian.Icon = "Interface\\Icons\\Inv_misc_head_dragon_black"
 FADEWT.Nefarian.LastEventAt = GetServerTime() - 10
@@ -120,7 +123,7 @@ end]]
 
 function FADEWT.Nefarian:OnMsgMonsterYell( npc )
     --print("NEFARIAN npc : " .. npc)
-    if npc == "High Overlord Saurfang" or npc == "Field Marshal Afrasiabi"then
+    if npc == L["High Overlord Saurfang"] or npc == L["Field Marshal Afrasiabi"] then
         local zId, zT = HBD:GetPlayerZone()
         FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
         FADEWT.Nefarian:SendBroadcastIfActiveTimer()

--- a/Timers/Nefarian.lua
+++ b/Timers/Nefarian.lua
@@ -120,7 +120,7 @@ end]]
 
 function FADEWT.Nefarian:OnMsgMonsterYell( npc )
     --print("NEFARIAN npc : " .. npc)
-    if npc == "High Overlord Saurfang" then
+    if npc == "High Overlord Saurfang" or npc == "Field Marshal Afrasiabi"then
         local zId, zT = HBD:GetPlayerZone()
         FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
         FADEWT.Nefarian:SendBroadcastIfActiveTimer()

--- a/Timers/Nefarian.lua
+++ b/Timers/Nefarian.lua
@@ -1,0 +1,219 @@
+local AddonName, FADEWT = ...
+local HBDP = LibStub("HereBeDragons-Pins-2.0")
+local HBD = LibStub("HereBeDragons-2.0")
+local Comm = LibStub("AceComm-3.0")
+local Serializer = LibStub("AceSerializer-3.0")
+
+FADEWT.Nefarian = {}
+FADEWT.Nefarian.Icon = "Interface\\Icons\\Inv_misc_head_dragon_black"
+FADEWT.Nefarian.LastEventAt = GetServerTime() - 10
+
+FADEWT.Nefarian.TimerLength = (60 * 60) * 8 -- Nefarian has 8 hour cooldown
+FADEWT.Nefarian.Frames = {}
+FADEWT.Nefarian.COMMKEY = "FADEWT-NEF3"
+FADEWT.Nefarian.Locations = {
+    ["1453"] = {64.9, 70},
+    ["1454"] = {51.73, 75},
+}
+
+function FADEWT.Nefarian:Tick()
+    for key, frame in pairs(FADEWT.Nefarian.Frames) do
+        frame.title:SetText(FADEWT.Nefarian:GetTimerStatus(key, frame))
+    end
+end
+
+function FADEWT.Nefarian:GetTimerStatus(key, f)
+    local nefarianTime = NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key]
+    local currTime = GetServerTime()
+    if nefarianTime then
+        if nefarianTime <= currTime then
+            if nefarianTime < currTime + (60 * 15) then
+                nefarianTime = nil
+                NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] = false
+            end
+            f.title:SetTextColor(0, 1, 0, 1)
+            return "Ready?"
+        end
+        if nefarianTime > currTime then
+            f.title:SetTextColor(1, 0, 0, 1)
+            -- Change color to green when 6 minutes or less on the timer
+            if (nefarianTime - currTime) < 360 then
+                f.title:SetTextColor(0, 1, 0, 1)
+            end
+            
+            local secondsLeft = nefarianTime - currTime
+            if secondsLeft <= 0 then
+                return "00:00:00";
+            else
+                hours = string.format("%02.f", math.floor(secondsLeft/3600));
+                mins = string.format("%02.f", math.floor(secondsLeft/60 - (hours*60)));
+                secs = string.format("%02.f", math.floor(secondsLeft - hours*3600 - mins *60));
+                return hours..":"..mins..":"..secs
+            end
+        end
+    end
+    f.title:SetTextColor(1, 0, 0, 1)
+    return ""
+end
+
+function FADEWT.Nefarian:GetMessageData()
+    local timers = {
+        ["1453"] = NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName]["1453"],
+        ["1454"] = NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName]["1454"],
+    }
+    return FADEWT.Nefarian.COMMKEY, timers
+end
+
+function FADEWT.Nefarian.ReceiveTimers(message, distribution, sender)
+    --local ok, receivedTimers = Serializer:Deserialize(message)
+    if not message then return end
+    local didChange = false
+    local currTime = GetServerTime()
+    for key,timer in pairs(message) do
+        
+        if timer ~= false and (NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] == nil or NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] == false) and FADEWT.Nefarian.Locations[key] ~= nil then
+            --FADEWT.Debug("RECV ONY TIMER", timer, (currTime + FADEWT.Nefarian.TimerLength + 10) > timer)
+            if (currTime + FADEWT.Nefarian.TimerLength + 20) > timer then
+                NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] = timer
+                didChange = true
+            end
+        end
+        if timer ~= false and NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] ~= false then
+            --FADEWT.Debug("RECV ONY TIMER", timer, (currTime + FADEWT.Nefarian.TimerLength + 10) > timer)
+            if (timer > NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key]) and FADEWT.Nefarian.Locations[key] ~= nil then
+                if (currTime + FADEWT.Nefarian.TimerLength + 20) > timer then
+                    NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] = timer
+                    didChange = true
+                end
+            end
+        end
+    end
+end
+
+function FADEWT.Nefarian:ReceiveNefarianBuff(key)
+    local currTime = GetServerTime()
+    local cdTime = currTime + FADEWT.Nefarian.TimerLength
+    NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName][key] = cdTime
+    FADEWT.Nefarian:BroadcastTimers()
+end
+
+--[[function FADEWT.Nefarian:OnUnitAura(unit)
+    if unit == "player" then
+        local name, expirationTime, sid, _
+        -- Todo: Check if this causes issues
+        for i = 1, 40 do
+            name, _, _, _, _, expirationTime, _, _, _, sid = UnitAura("player", i, "HELPFUL")
+            -- Check for buff Songflower Serenade
+            if sid == 22888 then
+                local currTime = GetTime()
+
+                -- Check if Sonflower has just been applied
+                if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) then
+                    local zId, zT = HBD:GetPlayerZone()
+                    FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
+                end
+            end
+        end
+        FADEWT.Nefarian:SendBroadcastIfActiveTimer()
+    end
+end]]
+
+function FADEWT.Nefarian:OnMsgMonsterYell( npc )
+    --print("NEFARIAN npc : " .. npc)
+    if npc == "High Overlord Saurfang" then
+        local zId, zT = HBD:GetPlayerZone()
+        FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
+        FADEWT.Nefarian:SendBroadcastIfActiveTimer()
+    end
+end
+
+
+-- Create an empty object if none exist
+function FADEWT.Nefarian:SetupDB()
+    if NefarianTimers == nil then
+        NefarianTimers = {}
+        NefarianTimers[FADEWT.Nefarian.COMMKEY] = {}
+        NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName] = {}
+    end
+    if NefarianTimers[FADEWT.Nefarian.COMMKEY] == nil then
+        NefarianTimers[FADEWT.Nefarian.COMMKEY] = {}
+    end
+    if NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName] == nil then
+        NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName] = {}
+    end
+    NefarianTimers[FADEWT.RealmName] = nil
+end
+-- Adds a frame to the world map
+-- In this case it's a Songflower icon with a possible timer below it
+function FADEWT.Nefarian:addFrameToWorldMap(map, frame, coords)
+    if HBDP then
+        FADEWT.Nefarian.Frames[map] = frame
+        HBDP:AddWorldMapIconMap(FADEWT.Nefarian.Frames[map], frame, tonumber(map), coords[1] / 100, coords[2] / 100, showFlag);
+    end
+end
+
+-- Creates our world map nodes on addon init
+function FADEWT.Nefarian:CreateFrames()
+    for map, coords in pairs(FADEWT.Nefarian.Locations) do
+        local frame = FADEWT.Nefarian:GetFrame()
+        FADEWT.Nefarian:addFrameToWorldMap(map, frame, coords)
+    end
+end
+
+
+function FADEWT.Nefarian:Init()
+    if FADEWTConfig.NefarianHidden ~= true then
+        FADEWT.Nefarian:CreateFrames()
+    end
+    --Comm:RegisterComm("FADEWT-ONY", FADEWT.Nefarian.ReceiveTimers)
+    FADEWT:RegisterMessageHandler(FADEWT.Nefarian.COMMKEY, FADEWT.Nefarian.ReceiveTimers)
+end
+
+-- Setup the frame
+function FADEWT.Nefarian:GetFrame()
+    local f = CreateFrame("Frame", nil, UIParent)
+    f:SetFrameStrata("HIGH")
+    f:SetWidth(16)
+    f:SetHeight(16)
+    f.background = f:CreateTexture(nil, "BACKGROUND")
+    f.background:SetAllPoints()
+    f.background:SetDrawLayer("BORDER", 1)
+    f.background:SetTexture(FADEWT.Nefarian.Icon)
+
+    f.title = f:CreateFontString("")
+    f.title:SetFontObject("GameFontNormalMed3")
+    f.title:SetTextColor(1,0,0,1)
+    f.title:SetText("")
+    f.title:ClearAllPoints()
+    f.title:SetPoint("BOTTOM", f, "BOTTOM", 0, -12)
+    f.title:SetTextHeight(12)
+    f.title:Show()
+    f:Show()
+    return f
+end
+
+function FADEWT.Nefarian.GetTimers()
+    return FADEWT.Nefarian.COMMKEY, NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName]
+end
+
+
+-- Sends a broadcast if we have any timers to broadcast
+function FADEWT.Nefarian:SendBroadcastIfActiveTimer()
+    local shouldBroadcast = false
+    for key,timer in pairs(NefarianTimers[FADEWT.Nefarian.COMMKEY][FADEWT.RealmName]) do
+        if timer then
+            shouldBroadcast = true
+        end
+    end
+
+    if shouldBroadcast then
+        FADEWT.Nefarian:BroadcastTimers()
+    end
+end
+
+function FADEWT.Nefarian:BroadcastTimers()
+    FADEWT:SendMessage()
+end
+
+-- Register our World Timer
+table.insert( FADEWT.WorldTimers, FADEWT.Nefarian )

--- a/Timers/Onyxia.lua
+++ b/Timers/Onyxia.lua
@@ -120,7 +120,7 @@ end]]
 
 function FADEWT.Onyxia:OnMsgMonsterYell( npc )
     --print("ONYXIA npc : " .. npc)
-    if npc == "Overlord Runthak" then
+    if npc == "Overlord Runthak" or npc == "Major Mattingly" then
         local zId, zT = HBD:GetPlayerZone()
         FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
         FADEWT.Onyxia:SendBroadcastIfActiveTimer()

--- a/Timers/Onyxia.lua
+++ b/Timers/Onyxia.lua
@@ -4,6 +4,8 @@ local HBD = LibStub("HereBeDragons-2.0")
 local Comm = LibStub("AceComm-3.0")
 local Serializer = LibStub("AceSerializer-3.0")
 
+local L = LibStub("AceLocale-3.0"):GetLocale("FADEWT")
+
 FADEWT.Onyxia = {}
 FADEWT.Onyxia.Icon = "Interface\\Icons\\Inv_misc_head_dragon_01"
 FADEWT.Onyxia.LastEventAt = GetServerTime() - 10
@@ -120,7 +122,7 @@ end]]
 
 function FADEWT.Onyxia:OnMsgMonsterYell( npc )
     --print("ONYXIA npc : " .. npc)
-    if npc == "Overlord Runthak" or npc == "Major Mattingly" then
+    if npc == L["Overlord Runthak"] or npc == L["Major Mattingly"] then
         local zId, zT = HBD:GetPlayerZone()
         FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
         FADEWT.Onyxia:SendBroadcastIfActiveTimer()

--- a/Timers/Onyxia.lua
+++ b/Timers/Onyxia.lua
@@ -13,7 +13,7 @@ FADEWT.Onyxia.Frames = {}
 FADEWT.Onyxia.COMMKEY = "FADEWT-ONY3"
 FADEWT.Onyxia.Locations = {
     ["1453"] = {60.50, 75.20},
-    ["1454"] = {51.73, 77.69},
+    ["1454"] = {51.73, 80},
 }
 
 function FADEWT.Onyxia:Tick()
@@ -97,7 +97,7 @@ function FADEWT.Onyxia:ReceiveOnyxiaBuff(key)
     FADEWT.Onyxia:BroadcastTimers()
 end
 
-function FADEWT.Onyxia:OnUnitAura(unit)
+--[[function FADEWT.Onyxia:OnUnitAura(unit)
     if unit == "player" then
         local name, expirationTime, sid, _
         -- Todo: Check if this causes issues
@@ -116,8 +116,16 @@ function FADEWT.Onyxia:OnUnitAura(unit)
         end
         FADEWT.Onyxia:SendBroadcastIfActiveTimer()
     end
-end
+end]]
 
+function FADEWT.Onyxia:OnMsgMonsterYell( npc )
+    --print("ONYXIA npc : " .. npc)
+    if npc == "Overlord Runthak" then
+        local zId, zT = HBD:GetPlayerZone()
+        FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
+        FADEWT.Onyxia:SendBroadcastIfActiveTimer()
+    end
+end
 
 -- Create an empty object if none exist
 function FADEWT.Onyxia:SetupDB()


### PR DESCRIPTION
My quick fix for separating Nefarian and Onyxia cooldowns, instead of checking for the buff to appear we are looking for what npc is yelling to determine which buff is going out. This unfortunately requires the use of localization to work on other clients. I added enUS and deDE for now to make sure that it works.

The Nefarian part is basically a copy of the Onyxia but changing the position of the icons and that the cooldown for Nefarian is 8h instead of 6h