### PR TITLE
Changed trigger to buff received, check head by time from yell

### DIFF
--- a/Timers/Nefarian.lua
+++ b/Timers/Nefarian.lua
@@ -18,6 +18,7 @@ FADEWT.Nefarian.Locations = {
     ["1453"] = {64.9, 70},
     ["1454"] = {51.73, 75},
 }
+FADEWT.Nefarian.YellTime = 0
 
 function FADEWT.Nefarian:Tick()
     for key, frame in pairs(FADEWT.Nefarian.Frames) do
@@ -100,7 +101,7 @@ function FADEWT.Nefarian:ReceiveNefarianBuff(key)
     FADEWT.Nefarian:BroadcastTimers()
 end
 
---[[function FADEWT.Nefarian:OnUnitAura(unit)
+function FADEWT.Nefarian:OnUnitAura(unit)
     if unit == "player" then
         local name, expirationTime, sid, _
         -- Todo: Check if this causes issues
@@ -111,7 +112,7 @@ end
                 local currTime = GetTime()
 
                 -- Check if Sonflower has just been applied
-                if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) then
+                if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) and ((currTime - FADEWT.Nefarian.YellTime) < 100) then
                     local zId, zT = HBD:GetPlayerZone()
                     FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
                 end
@@ -119,14 +120,15 @@ end
         end
         FADEWT.Nefarian:SendBroadcastIfActiveTimer()
     end
-end]]
+end
 
 function FADEWT.Nefarian:OnMsgMonsterYell( npc )
     --print("NEFARIAN npc : " .. npc)
     if npc == L["High Overlord Saurfang"] or npc == L["Field Marshal Afrasiabi"] then
-        local zId, zT = HBD:GetPlayerZone()
-        FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
-        FADEWT.Nefarian:SendBroadcastIfActiveTimer()
+        --local zId, zT = HBD:GetPlayerZone()
+        --FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
+        --FADEWT.Nefarian:SendBroadcastIfActiveTimer()
+        FADEWT.Nefarian.YellTime = GetTime()
     end
 end
 

--- a/Timers/Nefarian.lua
+++ b/Timers/Nefarian.lua
@@ -115,6 +115,7 @@ function FADEWT.Nefarian:OnUnitAura(unit)
                 if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) and ((currTime - FADEWT.Nefarian.YellTime) < 100) then
                     local zId, zT = HBD:GetPlayerZone()
                     FADEWT.Nefarian:ReceiveNefarianBuff(tostring(zId))
+                    FADEWT.Nefarian.YellTime = 0
                 end
             end
         end

--- a/Timers/Onyxia.lua
+++ b/Timers/Onyxia.lua
@@ -17,6 +17,7 @@ FADEWT.Onyxia.Locations = {
     ["1453"] = {60.50, 75.20},
     ["1454"] = {51.73, 80},
 }
+FADEWT.Onyxia.YellTime = 0
 
 function FADEWT.Onyxia:Tick()
     for key, frame in pairs(FADEWT.Onyxia.Frames) do
@@ -99,7 +100,7 @@ function FADEWT.Onyxia:ReceiveOnyxiaBuff(key)
     FADEWT.Onyxia:BroadcastTimers()
 end
 
---[[function FADEWT.Onyxia:OnUnitAura(unit)
+function FADEWT.Onyxia:OnUnitAura(unit)
     if unit == "player" then
         local name, expirationTime, sid, _
         -- Todo: Check if this causes issues
@@ -110,7 +111,7 @@ end
                 local currTime = GetTime()
 
                 -- Check if Sonflower has just been applied
-                if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) then
+                if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) and ((currTime - FADEWT.Onyxia.YellTime) < 100) then
                     local zId, zT = HBD:GetPlayerZone()
                     FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
                 end
@@ -118,14 +119,15 @@ end
         end
         FADEWT.Onyxia:SendBroadcastIfActiveTimer()
     end
-end]]
+end
 
 function FADEWT.Onyxia:OnMsgMonsterYell( npc )
     --print("ONYXIA npc : " .. npc)
     if npc == L["Overlord Runthak"] or npc == L["Major Mattingly"] then
-        local zId, zT = HBD:GetPlayerZone()
-        FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
-        FADEWT.Onyxia:SendBroadcastIfActiveTimer()
+        --local zId, zT = HBD:GetPlayerZone()
+        --FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
+        --FADEWT.Onyxia:SendBroadcastIfActiveTimer()
+        FADEWT.Onyxia.YellTime = GetTime()
     end
 end
 

--- a/Timers/Onyxia.lua
+++ b/Timers/Onyxia.lua
@@ -114,6 +114,7 @@ function FADEWT.Onyxia:OnUnitAura(unit)
                 if ((expirationTime - currTime) >= (60 * 120) - 1) and (currTime > (FADEWT.InitTime + 2)) and ((currTime - FADEWT.Onyxia.YellTime) < 100) then
                     local zId, zT = HBD:GetPlayerZone()
                     FADEWT.Onyxia:ReceiveOnyxiaBuff(tostring(zId))
+                    FADEWT.Onyxia.YellTime = 0
                 end
             end
         end


### PR DESCRIPTION
The idea now is to store the time for the yells and trigger the corresponding cool down (ony/nef) if the time from yell to buff is small enough.

The time from first yell to buff with no lag is roughly 15 seconds.

Pros: Starts the cool down when buff is received and not on the yell. Only starts one cool down, the previous solution started it twice.

Cons: Requires the person to witness both yell and buff to start the timer.
If there is massive lag, the time between yell and buff can be very long, to compensate I set 100 seconds as tolerance for now, but if both buffs are popped close to each other. Both timers would be set to the same value.